### PR TITLE
Keep uv.lock file and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ To bump the dependencies, first set any specifically desired versions (or leave 
 Then run the following command:
 ```
 # Report the previous requirements.txt file
-PREVIOUS_VERSION=v0.0.0  # the previous version arenaclient-bot-base image that we're comparing to
+cd docker && docker compose build bot # Build the bot image
 # Take the requirements output from the console of the following command and save it to before.requirements.txt
-docker run -it aiarena/arenaclient-bot-base:${PREVIOUS_VERSION} bash -c "pip install uv && uv export --format requirements.txt --no-hashes --no-header --no-annotate --no-cache -o requirements.txt"
+docker run -it aiarena/arenaclient-bot-base:latest bash -c "pip install uv && uv export --format requirements.txt --no-hashes --no-header --no-annotate --no-cache -o requirements.txt"
 
 # This will build the bot image and then run `uv sync` which will update the `uv.lock` file with the latest versions.
 # After running this, copy the requirements.txt content output from the console and save it to after.requirements.txt

--- a/docker/Dockerfile.bot
+++ b/docker/Dockerfile.bot
@@ -74,7 +74,6 @@ RUN pip install --upgrade --no-cache-dir pip && \
     && pip uninstall -y s2clientprotocol \
     # Remove cache created by uv and pip
     && rm -rf /root/.cache \
-    && rm -rf uv.lock \
     && rm -rf pyproject.toml.lock \
     && rm -rf requirements.txt.lock
 


### PR DESCRIPTION
Update readme:
- Add missing step for building the image with tag `aiarena/arenaclient-bot-base:latest` (image could be retagged to easily create "before.requirements.txt" after the image has been built)

Keep uv.lock file:
The lock file is gone when running 
```sh
docker run -it aiarena/arenaclient-bot-base:latest bash -c "pip install uv && uv export --format requirements.txt --no-hashes --no-header --no-annotate --no-cache -o requirements.txt"
```
which results in updating all packages before printing the output, resulting in a diff being non-existant.